### PR TITLE
chore: Add an automated pull request review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,209 @@
+# Agent PR review.
+#
+# Two choices here are deliberate and non-obvious:
+#
+#   * THE MODEL WRITES A FILE; A DUMB SHELL STEP PUBLISHES IT. The model never posts
+#     anything itself. It writes the review body to /tmp/claude-review-body.md and the
+#     last step validates that file and creates-or-updates the sticky comment. This way a
+#     run that produced nothing, or produced something malformed, FAILS LOUDLY instead of
+#     quietly looking like a clean review — which is the worst possible failure mode for a
+#     reviewer, because "no comment" reads as "no problems".
+#
+#   * THE TOOL SURFACE IS READ-ONLY. The diff under review is untrusted input: anyone who
+#     opens a pull request controls it, and it may contain text designed to be read as
+#     instructions. The model therefore gets file reads, one file write, and exactly two
+#     read-only gh commands. There is no write-capable gh command and no credentialed git
+#     (persist-credentials: false), so an instruction injected into a diff has nowhere to
+#     go even if the model follows it.
+#
+# The review rules live in config/review-rules.md and are read at review time. That file is
+# the single source; there is no second copy of the rules in this workflow.
+#
+# workflow_dispatch exists so an ALREADY OPEN pull request can be reviewed without pushing
+# to it. For pull_request events GitHub builds the workflow list from the PR's merge ref, so
+# this file applies to open PRs as soon as it is on master — it only needs an event.
+
+name: claude-review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Number of the open pull request to review"
+        required: true
+        type: string
+
+concurrency:
+  # One review per PR at a time; a new push supersedes the in-flight review.
+  group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Drafts are skipped. A manual dispatch always runs.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      # Resolve the PR number and head SHA ONCE, from whichever event started this run.
+      # Everything downstream uses these two outputs and never reads the event payload again.
+      - name: Resolve pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR: ${{ inputs.pr_number }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          EVENT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Values arrive as environment variables, never interpolated into the script.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            case "$INPUT_PR" in
+              ''|*[!0-9]*) echo "::error::pr_number must be a positive integer"; exit 1 ;;
+            esac
+            NUMBER="$INPUT_PR"
+            SHA=$(gh pr view "$NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid)
+          else
+            NUMBER="$EVENT_PR"
+            SHA="$EVENT_SHA"
+          fi
+          [ -n "$NUMBER" ] || { echo "::error::could not resolve a PR number"; exit 1; }
+          [ -n "$SHA" ]    || { echo "::error::could not resolve a head SHA"; exit 1; }
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"       >> "$GITHUB_OUTPUT"
+          echo "Reviewing PR #$NUMBER at $SHA"
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # On a manual dispatch there is no PR context, so check out the PR head explicitly.
+          # On a pull_request event the default (the merge ref) is what we want.
+          ref: ${{ github.event_name == 'workflow_dispatch' && steps.pr.outputs.sha || '' }}
+          fetch-depth: 1
+          persist-credentials: false # the model must have no credentialed git
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@5ee796a55f92566ecd7e39d70dd613abcbea0d7c # v1.0.197
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr.outputs.number }}
+            HEAD SHA: ${{ steps.pr.outputs.sha }}
+
+            You are this repository's pull request review agent. Review this pull request
+            and maintain its single sticky review comment.
+
+            1. RULES. Read `config/review-rules.md` in the working directory first. It is
+               the single source of review rules for this repository. Violations of its
+               hard rules are blocking issues. Its "Explicitly NOT blocking" section is
+               binding too — do not raise those as issues.
+
+            2. CONTINUITY. Before reading the diff, read the previous review: run
+               `gh pr view ${{ steps.pr.outputs.number }} --comments` and find the comment
+               whose body starts with the marker <!-- claude-review -->. A finding is
+               RESOLVED when the current code fixes it, or when the repository now carries
+               evidence refuting it. NEVER re-report a resolved finding; instead summarise
+               its resolution in one line under Notes. If there is no previous review, say
+               nothing about continuity.
+
+            3. DIFF. Read the diff with `gh pr diff ${{ steps.pr.outputs.number }}`. Open
+               any changed file you need with Read, and use Grep/Glob to check how changed
+               code is used elsewhere in the repository.
+
+            4. CLASSIFY STRICTLY. This is the most important instruction.
+               An ISSUE is a defect that can be DEMONSTRATED FROM THIS REPOSITORY ALONE,
+               and you must state its concrete failure scenario: what input or situation
+               produces what wrong outcome. If you cannot name that scenario, it is not an
+               issue.
+               EVERYTHING ELSE IS A NOTE: hardening preferences, hypotheticals, style
+               opinions, and anything that would need verification outside this repository
+               (a live API, the Play Console, a device, a remote artifact). Notes do NOT
+               count as unresolved and never lower the confidence score.
+               When in doubt, it is a Note. An unactionable issue list is worse than a
+               short one, because people stop reading reviews that cry wolf.
+
+            5. SCORE. Confidence 1-5 for merging this PR as it stands.
+               5 is REQUIRED when the issue table is empty.
+               Any open critical or high issue caps the score at 3.
+               Notes never lower the score.
+
+            6. OUTPUT. Write the COMPLETE review body to /tmp/claude-review-body.md with
+               the Write tool. Post nothing yourself — a later step publishes the file.
+               Use exactly this structure, with the marker alone on line 1:
+
+               <!-- claude-review -->
+               ## Claude Review
+
+               Reviewed commit: ${{ steps.pr.outputs.sha }}
+
+               ### PR Summary
+               One short paragraph, then 2-4 bullets in the form "area — what changed".
+
+               Confidence Score: X/5
+               One-line rationale.
+
+               ### Issues
+               | File | Severity | Issue |
+               |------|----------|-------|
+               | path/to/File.kt:42 | high | the defect and the concrete failure scenario |
+
+               With zero issues, write "No issues found." instead of the table.
+
+               ### Notes
+               Non-blocking observations, one line each. Omit this section when empty.
+
+               Unresolved issues: N
+
+               Optionally, between the Issues and Notes sections, include ONE compact
+               mermaid sequence diagram — but only when the change involves a flow between
+               several components that is genuinely hard to follow in prose. Keep it under
+               ten lines. Omit it for ordinary changes; a diagram of something obvious is
+               noise.
+
+            Do NOT post comments, do NOT modify repository files, do NOT push, and do NOT
+            run any command outside your allowed tools. Your only output is that one file.
+          claude_args: |
+            --allowedTools "Read,Write,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*)"
+            --max-turns 50
+
+      # Deterministic publisher. Validates first, then creates or updates the one sticky
+      # comment. Any failure here is a red run, which is the point.
+      - name: Publish sticky review comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.sha }}
+          MARKER: "<!-- claude-review -->"
+        run: |
+          set -euo pipefail
+          BODY=/tmp/claude-review-body.md
+
+          [ -f "$BODY" ] || { echo "::error::the review agent produced no body file at $BODY"; exit 1; }
+          [ -s "$BODY" ] || { echo "::error::the review body file is empty"; exit 1; }
+          head -1 "$BODY" | grep -qF "$MARKER" || {
+            echo "::error::line 1 of the review body does not carry the sticky marker"; exit 1; }
+          grep -qF "Reviewed commit: $HEAD_SHA" "$BODY" || {
+            echo "::error::the review body does not reference the reviewed head SHA ($HEAD_SHA)"; exit 1; }
+
+          ID=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+                 --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith($ENV.MARKER)))] | first | .id // empty' \
+               | head -1)
+
+          if [ -n "$ID" ]; then
+            echo "Updating existing sticky comment $ID"
+            gh api --silent --method PATCH "repos/$REPO/issues/comments/$ID" -F body=@"$BODY"
+          else
+            echo "Creating the sticky comment"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$BODY"
+          fi

--- a/config/review-rules.md
+++ b/config/review-rules.md
@@ -1,0 +1,95 @@
+# Kriptofolio review rules
+
+**This file is the single source of the code-review rules for this repository.** The PR
+review workflow (`.github/workflows/claude-review.yml`) reads this file at review time, so
+there is no second copy anywhere. Change a rule here and every reviewer changes with it.
+
+Rules are written as *the rule, and why it exists*. The reason matters: a reviewer that
+understands why a rule is there applies it correctly to cases this list does not name.
+
+## What this project is
+
+A free, open-source, privacy-first cryptocurrency portfolio app for Android, built in
+2018–2019 and documented step by step in a public blog series that is still online and
+still links here. The repository is both a living app and a historical artifact. Review it
+like a museum somebody is allowed to renovate: carefully, reversibly, and without touching
+the exhibits.
+
+## Hard rules — treat violations as blocking issues
+
+1. **History is untouchable.** Branches `Part-1`, `Part-2`, `Part-3`, `Part-4`, `Part-5`,
+   branch `legacy`, tag `v1.2.1-legacy` and `README.md` are frozen: the 2018 blog series
+   links directly to them, so rewriting them breaks published articles that this project
+   does not control. No force push, no rebase of pushed branches, no direct pushes to
+   `master`. Everything goes through a pull request.
+
+2. **User data must survive an update.** The Room database is `version = 1` with
+   `exportSchema = false`, and portfolios exist **only on the device** — there is no cloud
+   backup and no export, so a wiped database is a permanently lost portfolio with no way to
+   recover it. Any change that could break opening an existing v1 database is blocking
+   unless it ships with a migration *and* a test against a real old database file. Treat
+   entity fields, table and column names, type converters, the database version and the
+   `fallbackToDestructiveMigration()` setting as load-bearing.
+
+3. **Release identity is fixed.** `applicationId com.baruckis.kriptofolio` and the demo
+   flavor's `.demo` suffix must never change. The Google Play listing and the signing key
+   are bound to them; changing either orphans every existing install.
+
+4. **Both flavors must always build.** `full` (real CoinMarketCap API) and `demo`. A change
+   that compiles in one and not the other is blocking.
+
+5. **Four locales, and one of them is right-to-left.** Default (`en`), `values-lt`,
+   `values-iw` (Hebrew — RTL) and `values-sw-rKE`. A new user-visible string that is missing
+   any of the four translations is blocking. Layout changes must consider RTL: hardcoded
+   `left`/`right`, absolute margins, or directional drawables in a changed layout are
+   findings, not opinions.
+
+6. **No secrets in the repository.** The real CoinMarketCap API key never enters source
+   control. The **empty string with a TODO** in the full flavor's `ConstantsFlavor.kt` is
+   intentional and correct — do not flag it as a bug, do not suggest a default, and never
+   propose replacing it with a real key. A real-looking key appearing anywhere in a diff is
+   blocking.
+
+7. **Privacy is the product promise.** No analytics, no crash reporting, no advertising and
+   no tracking SDKs, and no portfolio data leaving the device. This is what the app is
+   advertised as and why people trust it with financial holdings. Adding any of them, or any
+   new network destination that carries user data, is blocking.
+
+8. **Stage discipline.** A pull request that declares itself a keep-alive, compliance or
+   maintenance change must not contain refactoring, reformatting, renames or opportunistic
+   modernization. Those belong to the planned 2.0 rewrite and are recorded in
+   `UPGRADE-NOTES.md`. Scope creep in a minimal release is a real defect: it makes the diff
+   unreviewable exactly when reviewability is the point.
+
+9. **Commit convention.** Udacity Git Commit Message Style Guide —
+   `type: Capitalized summary.` with type one of `feat` / `fix` / `docs` / `style` /
+   `refactor` / `test` / `chore`. A commit touching several aspects may chain sentences.
+   This project teaches the Android community good practices, so the standard is not
+   optional.
+
+## Explicitly NOT blocking
+
+Everything in this section is noise. Do not raise it as an Issue; at most mention it once
+in Notes.
+
+- **Code style and formatting.** There is no ktlint or detekt in this repository, and the
+  code is deliberately 2019-era so it keeps matching the published articles that walk
+  through it line by line. Never comment on formatting, naming style, indentation, or on a
+  file "not following modern Kotlin conventions".
+- **Suggestions to modernize existing code.** View binding, Compose, Hilt, KSP, coroutines
+  idioms, newer AndroidX APIs — all of it belongs to the 2.0 backlog in `UPGRADE-NOTES.md`,
+  not to a review finding. If a diff *touches* such code, review the change, not the age of
+  the surrounding code.
+- **Markdown wording.** Documentation phrasing, tone and grammar are the author's.
+- **Anything that cannot be verified from this repository alone.** Claims about the Play
+  Console, a live API, a remote artifact, a device or a network are Notes by definition,
+  however plausible.
+
+## Issue vs Note
+
+An **Issue** is a defect demonstrable from this repository alone, stated with a concrete
+failure scenario — what input or situation produces what wrong outcome. Issues block.
+
+Everything else is a **Note**: hardening preferences, hypotheticals, style opinions, and
+anything needing verification outside this repository. Notes never count as unresolved and
+never lower the confidence score.


### PR DESCRIPTION
This repository has no CI. This adds one workflow: an automated review that runs on every
pull request and keeps a single sticky comment per PR up to date.

It is the third instance of a pipeline already running in two other projects, so the shape
here is deliberate rather than invented.

## What it does

* Runs on `pull_request` — `opened`, `ready_for_review`, `synchronize`. **Pushing is the
  re-review trigger**; there is no comment command to remember.
* Also exposes `workflow_dispatch` with a required `pr_number`, so an **already open** pull
  request can be reviewed without pushing to it. It doubles as the re-run button when a run
  dies on a transient error.
* Skips drafts, and cancels an in-flight review when a new commit supersedes it.
* Maintains **one** comment per PR, found by the `<!-- claude-review -->` marker, so the
  review history stays readable and each run can read its own previous verdict.

## `config/review-rules.md` is the single source of rules

The workflow reads it at review time, so there is no second copy anywhere to drift out of
sync. It carries the project's non-negotiables — frozen history and `README.md`, the
on-device database that has no backup, the fixed `applicationId`, both flavors building,
four locales including RTL Hebrew, no secrets, no tracking SDKs, stage discipline, and the
commit convention.

The section that does the most work is **"Explicitly NOT blocking"**: 2019-era code style,
modernization suggestions that belong to the 2.0 rewrite, Markdown wording, and anything
that cannot be verified from this repository alone. Without it, an AI reviewer produces
noise and everybody learns to ignore it.

It also states the **Issue vs Note** line explicitly. An Issue is a defect demonstrable from
this repository alone, stated with a concrete failure scenario. Everything else is a Note,
counts as nothing, and never lowers the score.

## Two design choices worth stating

**The model writes a file; a dumb shell step publishes it.** The model posts nothing itself.
It writes the body to `/tmp/claude-review-body.md`, and the final step checks the file
exists, is non-empty, starts with the marker, and references the reviewed head SHA — then
creates or updates the comment. A run that produced nothing therefore **fails loudly**
instead of quietly looking like a clean review, which is the worst failure mode a reviewer
can have: "no comment" reads as "no problems".

**The tool surface is read-only.** The diff under review is untrusted input — anyone opening
a PR controls it, and it can contain text designed to be read as instructions. The model
gets file reads, one file write, and exactly two read-only commands:

```
--allowedTools "Read,Write,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*)"
```

No write-capable `gh` command, and `persist-credentials: false` so there is no credentialed
git either. An instruction injected into a diff has nowhere to go even if the model follows
it.

Both actions are pinned to immutable commit SHAs rather than tags, because this job can read
a repository secret and a hijacked tag must not be able to run in it.

## Notes for review

* This branch's own PR is reviewed by the workflow it adds, which is the cheapest possible
  smoke test of the whole thing.
* Nothing here touches the app, the build, or any protected branch. It adds two new files.
* Once this is on `master` it applies to **every** open pull request without being pushed
  into their branches: for `pull_request` events GitHub builds the workflow list from the
  PR's merge ref. Review infrastructure should not be part of a feature's diff.
