### PR TITLE
chore: Restore .idea/modules.xml, deleted by accident in #11

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/Kriptofolio.iml" filepath="$PROJECT_DIR$/.idea/modules/Kriptofolio.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/Kriptofolio.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/Kriptofolio.app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/Kriptofolio.app.androidTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/Kriptofolio.app.androidTest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/Kriptofolio.app.main.iml" filepath="$PROJECT_DIR$/.idea/modules/app/Kriptofolio.app.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/Kriptofolio.app.unitTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/Kriptofolio.app.unitTest.iml" />
+    </modules>
+  </component>
+</project>


### PR DESCRIPTION
Restores one file that was deleted by mistake, byte for byte.

## What happened

`.idea/modules.xml` had been tracked since the project was created in **2018**. Commit
`1629fba` — *"chore: Raised the Gradle wrapper to 8.8 so Android Studio can sync"*, merged as
part of #11 — deleted it. Nothing about a Gradle wrapper upgrade required that, and its commit
message does not mention it, because it was not intended.

## Why it happened

Android Studio rewrites `.idea/` on its own and its git integration had left the deletion
**staged**. The commit was made as:

```
git add UPGRADE-NOTES.md gradle/wrapper/gradle-wrapper.properties gradlew gradlew.bat
git commit -F - <<'EOF'
...
```

`git commit` without a pathspec commits *everything already in the index*, not just what was
just added. So it swept up the staged deletion silently — no warning, nothing in the diff
summary that draws the eye, and the PR was reviewed for its Gradle change.

The repository's own minimal-diff rule is the one that was broken: a commit changes only what
its task requires.

## The fix

`.idea/modules.xml` is restored to exactly the content it had before the deletion — verified
identical against `4f727ed`, the last commit that legitimately touched it.

## Not fixed here

Whether `.idea/` should be tracked in this repository at all is a real question — Android
Studio churns those files constantly, and this is the second time in one week that the churn
has tried to ride along with an unrelated commit. But that is a deliberate decision for the 2.0
rewrite, not something to settle inside a fix for an accident.

For anyone working in this repository meanwhile, a local `pre-commit` hook that refuses staged
`.idea/` paths costs nothing and catches this class of mistake at the moment it happens.
`.git/hooks/` is never pushed, so it protects whoever installs it without affecting anyone else.
