### PR TITLE
docs: Write down what happens to branches after merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,31 @@ to renovate: carefully, reversibly, and without touching the exhibits.
 - Never push directly to `master`. All work goes through a feature branch and a pull request
   that the human reviews and merges.
 
+## Branches
+
+The branch list in this repository is documentation. Someone arriving from the 2018 article
+series sees `Part-1`…`Part-5` and immediately understands where they have landed. That signal
+only survives while the list stays short, so every branch here is one of two kinds.
+
+**Exhibits — kept forever.** `Part-1`…`Part-5` contain commits that are not on `master` and
+never will be; deleting one destroys history that the published articles link to. `legacy`
+marks the state of the app before the modernization. These are the protected branches listed
+above.
+
+**Working branches — deleted once their pull request is merged.** Everything else: a feature,
+a fix, a documentation change, a CI change. Nothing is lost by deleting one. Its commits stay
+reachable from `master`, and the pull request keeps the full diff, the review and the
+discussion — GitHub can restore the branch from the pull request page at any time. The
+durable markers for a release are tags (`v1.2.1`, `v1.2.2`), never branches.
+
+Deletion is **deliberate, never automatic**. `delete_branch_on_merge` is intentionally switched
+off in the repository settings: the owner decides when a branch goes and says so. So:
+
+- never delete a branch on your own initiative — ask, and wait to be asked;
+- before deleting any branch, verify it is an ancestor of `master`
+  (`git merge-base --is-ancestor origin/<branch> origin/master`) and refuse if it is not;
+- never delete, rename or rewrite `Part-1`…`Part-5`, `legacy`, or `master`.
+
 ## Project facts
 
 - `applicationId com.baruckis.kriptofolio` (never change; Play listing and signing depend on it).


### PR DESCRIPTION
One file, `AGENTS.md`, 25 added lines. No code.

## Why

The branch list in this repository is documentation. Someone arriving from the 2018 article
series sees `Part-1`…`Part-5` and immediately knows where they have landed. That only works
while the list stays short — and five merged working branches had already piled up next to the
six historical ones.

They have now been deleted (`stage0/target-sdk-35`, `ci/pr-review`, `docs/release-procedure`,
`docs/review-rules-demo-key`, `fix/restore-idea-modules`), leaving `Part-1`…`Part-5`, `legacy`
and `master`. This PR writes down the rule so it does not have to be rediscovered.

## The distinction the rule makes

| | Exhibits | Working branches |
|---|---|---|
| Examples | `Part-1`…`Part-5`, `legacy` | features, fixes, docs, CI |
| Contain commits not on `master` | **yes** — deleting destroys history | no |
| Lifetime | forever | until their PR is merged |
| What remains after deletion | — | commits on `master`, plus the PR's diff, review and discussion; branch restorable from the PR page |

The durable markers for a release are **tags**, never branches.

## Deletion stays deliberate

`delete_branch_on_merge` is intentionally **off**. This is a repository that doubles as a
museum, so branch removal should be a decision somebody makes, not a setting that fires while
nobody is looking. The rule therefore tells an agent to:

- never delete a branch on its own initiative — ask, and wait to be asked;
- verify a branch is an ancestor of `master` before deleting it, and refuse if it is not;
- never touch `Part-1`…`Part-5`, `legacy` or `master`.

That middle check is the one that matters: `Part-1`…`Part-5` are **not** ancestors of `master`,
so a mechanical "delete merged branches" sweep would spare them — but only by luck. Making the
check explicit means it is not luck.
